### PR TITLE
nvptx-none-as: Run ptxas with -O0.

### DIFF
--- a/nvptx-as.c
+++ b/nvptx-as.c
@@ -991,6 +991,7 @@ This program has absolutely no warranty.\n",
       obstack_ptr_grow (&argv_obstack, outname);
       obstack_ptr_grow (&argv_obstack, "--gpu-name");
       obstack_ptr_grow (&argv_obstack, "sm_30");
+      obstack_ptr_grow (&argv_obstack, "-O0");
       obstack_ptr_grow (&argv_obstack, NULL);
       char *const *new_argv = XOBFINISH (&argv_obstack, char *const *);
       fork_execute (new_argv[0], new_argv);


### PR DESCRIPTION
We don't want it to spend time on any code optimizations that will end up in
/dev/null.

For example, with CUDA_CACHE_DISABLE=1, picking the best results from three
runs each without and with this patch, we get:

               default      -O0
    gcc        4 h          3 h
    g++        1 h 30 min   1 h 30 min
    gfortran   4 h          3 h 30 min