### PR TITLE
Multiple fixes

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -10,8 +10,6 @@ LIBS = @LIBS@
 
 CUDA_DRIVER_CPPFLAGS = @CUDA_DRIVER_CPPFLAGS@
 CUDA_DRIVER_LDFLAGS = @CUDA_DRIVER_LDFLAGS@
-CUDA_RUNTIME_CPPFLAGS = @CUDA_RUNTIME_CPPFLAGS@
-CUDA_RUNTIME_LDFLAGS = @CUDA_RUNTIME_LDFLAGS@
 
 AR = @AR@
 RANLIB = @RANLIB@
@@ -48,11 +46,11 @@ nvptx-none-ld: $(srcdir)/nvptx-ld.c libiberty.stmp $(srcdir)/version.h
 		-Llibiberty -liberty $(LDFLAGS) $(LIBS)
 
 nvptx-none-run: $(srcdir)/nvptx-run.c libiberty.stmp $(srcdir)/version.h
-	$(CXX) $(CUDA_DRIVER_CPPFLAGS) $(CUDA_RUNTIME_CPPFLAGS) \
+	$(CXX) $(CUDA_DRIVER_CPPFLAGS) \
 		$(CPPFLAGS_ALL) $(CXXFLAGS) -I$(srcdir)/include \
 		$< -o $@ \
-		$(CUDA_DRIVER_LDFLAGS) $(CUDA_RUNTIME_LDFLAGS) \
-		-Llibiberty -liberty $(LDFLAGS) $(LIBS) -lcuda -lcudart
+		$(CUDA_DRIVER_LDFLAGS) \
+		-Llibiberty -liberty $(LDFLAGS) $(LIBS) -lcuda
 
 .PHONY: install
 install: all

--- a/configure
+++ b/configure
@@ -557,8 +557,6 @@ ac_subst_vars='LTLIBOBJS
 LIBOBJS
 subdirs
 NVPTX_RUN
-CUDA_RUNTIME_LDFLAGS
-CUDA_RUNTIME_CPPFLAGS
 CUDA_DRIVER_LDFLAGS
 CUDA_DRIVER_CPPFLAGS
 AR
@@ -626,9 +624,6 @@ with_bugurl
 with_cuda_driver
 with_cuda_driver_include
 with_cuda_driver_lib
-with_cuda_runtime
-with_cuda_runtime_include
-with_cuda_runtime_lib
 '
       ac_precious_vars='build_alias
 host_alias
@@ -1260,17 +1255,6 @@ Optional Packages:
                           files
   --with-cuda-driver-lib=PATH
                           specify directory for the installed CUDA driver
-                          library
-  --with-cuda-runtime=PATH
-                          specify prefix directory for installed CUDA runtime
-                          package. Equivalent to
-                          --with-cuda-runtime-include=PATH/include plus
-                          --with-cuda-runtime-lib=PATH/lib
-  --with-cuda-runtime-include=PATH
-                          specify directory for installed CUDA runtime include
-                          files
-  --with-cuda-runtime-lib=PATH
-                          specify directory for the installed CUDA runtime
                           library
 
 Some influential environment variables:
@@ -3256,46 +3240,12 @@ if test "x$with_cuda_driver_lib" != x; then
   CUDA_DRIVER_LDFLAGS="-L$with_cuda_driver_lib"
 fi
 
-# Look for the CUDA runtime package.
-CUDA_RUNTIME_CPPFLAGS=
-
-CUDA_RUNTIME_LDFLAGS=
-
-
-# Check whether --with-cuda-runtime was given.
-if test "${with_cuda_runtime+set}" = set; then :
-  withval=$with_cuda_runtime;
-fi
-
-
-# Check whether --with-cuda-runtime-include was given.
-if test "${with_cuda_runtime_include+set}" = set; then :
-  withval=$with_cuda_runtime_include;
-fi
-
-
-# Check whether --with-cuda-runtime-lib was given.
-if test "${with_cuda_runtime_lib+set}" = set; then :
-  withval=$with_cuda_runtime_lib;
-fi
-
-if test "x$with_cuda_runtime" != x; then
-  CUDA_RUNTIME_CPPFLAGS=-I$with_cuda_runtime/include
-  CUDA_RUNTIME_LDFLAGS="-L$with_cuda_runtime/lib"
-fi
-if test "x$with_cuda_runtime_include" != x; then
-  CUDA_RUNTIME_CPPFLAGS=-I$with_cuda_runtime_include
-fi
-if test "x$with_cuda_runtime_lib" != x; then
-  CUDA_RUNTIME_LDFLAGS="-L$with_cuda_runtime_lib"
-fi
-
 save_CPPFLAGS=$CPPFLAGS
-CPPFLAGS="$CUDA_DRIVER_CPPFLAGS $CUDA_RUNTIME_CPPFLAGS $CPPFLAGS"
+CPPFLAGS="$CUDA_DRIVER_CPPFLAGS $CPPFLAGS"
 save_LDFLAGS=$LDFLAGS
-LDFLAGS="$CUDA_DRIVER_LDFLAGS $CUDA_RUNTIME_LDFLAGS $LDFLAGS"
+LDFLAGS="$CUDA_DRIVER_LDFLAGS $LDFLAGS"
 save_LIBS=$LIBS
-LIBS="$LIBS -lcuda -lcudart"
+LIBS="$LIBS -lcuda"
 
 
 for ac_func in cuGetErrorName cuGetErrorString
@@ -3335,16 +3285,16 @@ cat >>confdefs.h <<_ACEOF
 _ACEOF
 
 
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for extra programs to build requiring -lcudart" >&5
-$as_echo_n "checking for extra programs to build requiring -lcudart... " >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for extra programs to build requiring -lcuda" >&5
+$as_echo_n "checking for extra programs to build requiring -lcuda... " >&6; }
 NVPTX_RUN=
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
-#include <cuda_runtime.h>
+#include <cuda.h>
 int
 main ()
 {
-cudaDeviceReset ();
+cuInit (0);
   ;
   return 0;
 }

--- a/configure.ac
+++ b/configure.ac
@@ -41,49 +41,22 @@ if test "x$with_cuda_driver_lib" != x; then
   CUDA_DRIVER_LDFLAGS="-L$with_cuda_driver_lib"
 fi
 
-# Look for the CUDA runtime package.
-CUDA_RUNTIME_CPPFLAGS=
-AC_SUBST([CUDA_RUNTIME_CPPFLAGS])
-CUDA_RUNTIME_LDFLAGS=
-AC_SUBST([CUDA_RUNTIME_LDFLAGS])
-AC_ARG_WITH(cuda-runtime,
-        [AS_HELP_STRING([--with-cuda-runtime=PATH],
-                [specify prefix directory for installed CUDA runtime package.
-                 Equivalent to --with-cuda-runtime-include=PATH/include
-                 plus --with-cuda-runtime-lib=PATH/lib])])
-AC_ARG_WITH(cuda-runtime-include,
-        [AS_HELP_STRING([--with-cuda-runtime-include=PATH],
-                [specify directory for installed CUDA runtime include files])])
-AC_ARG_WITH(cuda-runtime-lib,
-        [AS_HELP_STRING([--with-cuda-runtime-lib=PATH],
-                [specify directory for the installed CUDA runtime library])])
-if test "x$with_cuda_runtime" != x; then
-  CUDA_RUNTIME_CPPFLAGS=-I$with_cuda_runtime/include
-  CUDA_RUNTIME_LDFLAGS="-L$with_cuda_runtime/lib"
-fi
-if test "x$with_cuda_runtime_include" != x; then
-  CUDA_RUNTIME_CPPFLAGS=-I$with_cuda_runtime_include
-fi
-if test "x$with_cuda_runtime_lib" != x; then
-  CUDA_RUNTIME_LDFLAGS="-L$with_cuda_runtime_lib"
-fi
-
 save_CPPFLAGS=$CPPFLAGS
-CPPFLAGS="$CUDA_DRIVER_CPPFLAGS $CUDA_RUNTIME_CPPFLAGS $CPPFLAGS"
+CPPFLAGS="$CUDA_DRIVER_CPPFLAGS $CPPFLAGS"
 save_LDFLAGS=$LDFLAGS
-LDFLAGS="$CUDA_DRIVER_LDFLAGS $CUDA_RUNTIME_LDFLAGS $LDFLAGS"
+LDFLAGS="$CUDA_DRIVER_LDFLAGS $LDFLAGS"
 save_LIBS=$LIBS
-LIBS="$LIBS -lcuda -lcudart"
+LIBS="$LIBS -lcuda"
 
 AC_CHECK_FUNCS([[cuGetErrorName] [cuGetErrorString]])
 AC_CHECK_DECLS([[cuGetErrorName], [cuGetErrorString]],
   [], [], [[#include <cuda.h>]])
 
-AC_MSG_CHECKING([for extra programs to build requiring -lcudart])
+AC_MSG_CHECKING([for extra programs to build requiring -lcuda])
 NVPTX_RUN=
 AC_LINK_IFELSE([AC_LANG_PROGRAM(
-  [#include <cuda_runtime.h>],
-  [cudaDeviceReset ();])],
+  [#include <cuda.h>],
+  [cuInit (0);])],
   [NVPTX_RUN=nvptx-none-run])
 AC_MSG_RESULT($NVPTX_RUN)
 AC_SUBST(NVPTX_RUN)

--- a/nvptx-run.c
+++ b/nvptx-run.c
@@ -71,22 +71,16 @@ compile_file (FILE *f, CUmodule *phModule, CUfunction *phKernel)
 {
   CUresult r;
    
+  char elog[8192];
+  CUjit_option opts[] = {
+    CU_JIT_ERROR_LOG_BUFFER, CU_JIT_ERROR_LOG_BUFFER_SIZE_BYTES
+  };
+  void *optvals[] = {
+    elog, (void*) sizeof elog
+  };
   CUlinkState linkstate;
-  CUjit_option opts[5];
-  void *optvals[5];
-#define LOGSIZE 8192
-  char elog[LOGSIZE];
 
-  opts[0] = CU_JIT_TARGET;
-  optvals[0] = (void *) CU_TARGET_COMPUTE_30;
-
-  opts[1] = CU_JIT_ERROR_LOG_BUFFER;
-  optvals[1] = &elog[0];
-
-  opts[2] = CU_JIT_ERROR_LOG_BUFFER_SIZE_BYTES;
-  optvals[2] = (void *) LOGSIZE;
-
-  r = cuLinkCreate (3, opts, optvals, &linkstate);
+  r = cuLinkCreate (sizeof opts / sizeof *opts, opts, optvals, &linkstate);
   fatal_unless_success (r, "cuLinkCreate failed");
   
   fseek (f, 0, SEEK_END);

--- a/nvptx-run.c
+++ b/nvptx-run.c
@@ -20,7 +20,6 @@
 #include <string.h>
 #include <stdarg.h>
 #include <cuda.h>
-#include <cuda_runtime.h>
 
 #include "version.h"
 
@@ -251,7 +250,6 @@ This program has absolutely no warranty.\n",
     cuModuleUnload (hModule);
 
   cuCtxDestroy (ctx);
-  cudaDeviceReset ();
 
   return result;
 }


### PR DESCRIPTION
Hello,

this pull request fixes running on sm_5x hardware by dropping CU_JIT_TARGET option, and addresses two other issues:

  - #2: call to cudaDeviceReset is superfluous and can be removed, allowing to drop dependency on CUDA runtime library
  - #8: GPU stack size had to be adjusted in the past, and will likely need to be adjusted for some Maxwell devices too; implement automatic sizing.