### PR TITLE
[nvptx-run] Fix greedy option parsing

### DIFF
--- a/nvptx-run.c
+++ b/nvptx-run.c
@@ -155,7 +155,7 @@ main (int argc, char **argv)
 {
   int o;
   long stack_size = 0, heap_size = 256 * 1024 * 1024, num_lanes = 1;
-  while ((o = getopt_long (argc, argv, "S:H:L:O:gGhV", long_options, 0)) != -1)
+  while ((o = getopt_long (argc, argv, "+S:H:L:O:gGhV", long_options, 0)) != -1)
     {
       switch (o)
 	{


### PR DESCRIPTION
Consider test.c:
...
int main (int argc, char **argv) {
  printf ("argc: %u\n", argc);
  return 0;
}
...
such that we have:
...
$ nvptx-none-run a.out
argc: 1
$ nvptx-none-run a.out bla
argc: 2
...

Given that the usage indicates that the program seperates the nvptx options
and the program arguments:
...
$ nvptx-none-run --help
Usage: nvptx-none-run [option...] program [argument...]
...
I'd expect:
...
$ nvptx-none-run a.out bla -V
argc: 3
...
but instead we get:
...
$ ./run.sh a.out bla -V
nvtpx-none-run (nvptx-tools) 1.0
<COPYRIGHT>
$
...

Fix this by calling getopt_long with optstring starting with '+'.