### PR TITLE
Ensure :VAR_MAP and :FUNC_MAP are output in order

### DIFF
--- a/nvptx-as.c
+++ b/nvptx-as.c
@@ -703,6 +703,7 @@ static Token *
 parse_file (Token *tok)
 {
   Stmt *comment = 0;
+  unsigned has_map = 0;
 
   if (tok->kind == K_comment)
     {
@@ -711,9 +712,15 @@ parse_file (Token *tok)
       while (tok->kind == K_comment)
 	{
 	  if (strncmp (tok->ptr, ":VAR_MAP ", 9) == 0)
-	    record_id (tok->ptr + 9, &vars_tail);
+	    {
+	      record_id (tok->ptr + 9, &vars_tail);
+	      has_map = 1;
+	    }
 	  if (strncmp (tok->ptr, ":FUNC_MAP ", 10) == 0)
-	    record_id (tok->ptr + 10, &funcs_tail);
+	    {
+	      record_id (tok->ptr + 10, &funcs_tail);
+	      has_map = 1;
+	    }
 	  tok++;
 	}
       comment = alloc_comment (start, tok);
@@ -735,7 +742,7 @@ parse_file (Token *tok)
 	{
 	  unsigned vis = 0;
 	  symbol *def = 0;
-	  unsigned is_decl = 0;
+	  unsigned is_decl = has_map;
 	  Token *start, *def_token = 0;
 
 	  for (start = tok;


### PR DESCRIPTION
Before, only if there is an '.extern', is_decl is set and only
then the variable/function is added to 'decls'. However, global
variables/functions may not have .extern - even if they show up
with :VAR_MAP and :FUNC_MAP. GCC's mkoffload uses the latter and
requires that the order matches the original order.

As the output is done as:
```C
	write_stmts (out, rev_stmts (decls));
	htab_traverse (symbol_table, traverse, (void *)out);
	write_stmts (out, rev_stmts (fns));
```
it might have happen that :VAR_MAP/:FUNC_MAP lines will be output
in hash-map order, which can cause the wrong order.

https://gcc.gnu.org/PR100059
* nvptx-as.c (parse_file): Set is_decl when there is a :VAR_MAP or :FUNC_MAP.