### PR TITLE
as: Deal with CUDA 11.0, "Support for Kepler 'sm_30' and 'sm_32' architecture based products is dropped"

### DIFF
--- a/test/as/ptxas/invoke-1.test
+++ b/test/as/ptxas/invoke-1.test
@@ -49,3 +49,75 @@ RUN: rm -f %t*
 RUN: %dummy_ptxas_path DUMMY_PTXAS_LOG=%t.dummy_ptxas_log %target_as_cmd -o /dev/null %S/../bare-1.s -m sm_2020
 RUN: sed -e 's|sm_35|sm_2020|g' < %S/dummy_ptxas_log.golden > %t.dummy_ptxas_log.golden
 RUN: cmp %t.dummy_ptxas_log.golden %t.dummy_ptxas_log
+
+
+Implicit '--verify', preamble '.target sm_2022'
+
+RUN: rm -f %t*
+RUN: sed -e 's|sm_35|sm_2022|g' < %S/../bare-1.s > %t.bare-1.s
+RUN: %dummy_ptxas_path DUMMY_PTXAS_LOG=%t.dummy_ptxas_log %target_as_cmd -o /dev/null %t.bare-1.s
+RUN: sed -e 's|sm_35|sm_2022|g' < %S/dummy_ptxas_log.golden > %t.dummy_ptxas_log.golden
+RUN: cmp %t.dummy_ptxas_log.golden %t.dummy_ptxas_log
+
+
+Special handling re CUDA 11.0, "Support for Kepler 'sm_30' and 'sm_32' architecture based products is dropped"
+
+Preamble '.target sm_3': doesn't exist; not special-cased.
+
+RUN: rm -f %t*
+RUN: sed -e 's|sm_35|sm_3|g' < %S/../bare-1.s > %t.bare-1.s
+RUN: %dummy_ptxas_path DUMMY_PTXAS_LOG=%t.dummy_ptxas_log %target_as_cmd -o /dev/null %t.bare-1.s
+RUN: sed -e 's|sm_35|sm_3|g' < %S/dummy_ptxas_log.golden > %t.dummy_ptxas_log.golden
+RUN: cmp %t.dummy_ptxas_log.golden %t.dummy_ptxas_log
+
+Preamble '.target sm_30': special-cased to '--gpu-name sm_35'.
+
+RUN: rm -f %t*
+RUN: sed -e 's|sm_35|sm_30|g' < %S/../bare-1.s > %t.bare-1.s
+RUN: %dummy_ptxas_path DUMMY_PTXAS_LOG=%t.dummy_ptxas_log %target_as_cmd -o /dev/null %t.bare-1.s
+RUN: cmp %S/dummy_ptxas_log.golden %t.dummy_ptxas_log
+
+Preamble '.target sm_31': doesn't exist; not special-cased.
+
+RUN: rm -f %t*
+RUN: sed -e 's|sm_35|sm_31|g' < %S/../bare-1.s > %t.bare-1.s
+RUN: %dummy_ptxas_path DUMMY_PTXAS_LOG=%t.dummy_ptxas_log %target_as_cmd -o /dev/null %t.bare-1.s
+RUN: sed -e 's|sm_35|sm_31|g' < %S/dummy_ptxas_log.golden > %t.dummy_ptxas_log.golden
+RUN: cmp %t.dummy_ptxas_log.golden %t.dummy_ptxas_log
+
+Preamble '.target sm_32': special-cased to '--gpu-name sm_35'.
+
+RUN: rm -f %t*
+RUN: sed -e 's|sm_35|sm_32|g' < %S/../bare-1.s > %t.bare-1.s
+RUN: %dummy_ptxas_path DUMMY_PTXAS_LOG=%t.dummy_ptxas_log %target_as_cmd -o /dev/null %t.bare-1.s
+RUN: cmp %S/dummy_ptxas_log.golden %t.dummy_ptxas_log
+
+Preamble '.target sm_35': not special-cased.
+
+RUN: rm -f %t*
+RUN: %dummy_ptxas_path DUMMY_PTXAS_LOG=%t.dummy_ptxas_log %target_as_cmd -o /dev/null %S/../bare-1.s
+RUN: cmp %S/dummy_ptxas_log.golden %t.dummy_ptxas_log
+
+Preamble '.target sm_37': not special-cased.
+
+RUN: rm -f %t*
+RUN: sed -e 's|sm_35|sm_37|g' < %S/../bare-1.s > %t.bare-1.s
+RUN: %dummy_ptxas_path DUMMY_PTXAS_LOG=%t.dummy_ptxas_log %target_as_cmd -o /dev/null %t.bare-1.s
+RUN: sed -e 's|sm_35|sm_37|g' < %S/dummy_ptxas_log.golden > %t.dummy_ptxas_log.golden
+RUN: cmp %t.dummy_ptxas_log.golden %t.dummy_ptxas_log
+
+Preamble '.target sm_30x': doesn't exist; not special-cased.
+
+RUN: rm -f %t*
+RUN: sed -e 's|sm_35|sm_30x|g' < %S/../bare-1.s > %t.bare-1.s
+RUN: %dummy_ptxas_path DUMMY_PTXAS_LOG=%t.dummy_ptxas_log %target_as_cmd -o /dev/null %t.bare-1.s
+RUN: sed -e 's|sm_35|sm_30x|g' < %S/dummy_ptxas_log.golden > %t.dummy_ptxas_log.golden
+RUN: cmp %t.dummy_ptxas_log.golden %t.dummy_ptxas_log
+
+Preamble '.target sm_32x': doesn't exist; not special-cased.
+
+RUN: rm -f %t*
+RUN: sed -e 's|sm_35|sm_32x|g' < %S/../bare-1.s > %t.bare-1.s
+RUN: %dummy_ptxas_path DUMMY_PTXAS_LOG=%t.dummy_ptxas_log %target_as_cmd -o /dev/null %t.bare-1.s
+RUN: sed -e 's|sm_35|sm_32x|g' < %S/dummy_ptxas_log.golden > %t.dummy_ptxas_log.golden
+RUN: cmp %t.dummy_ptxas_log.golden %t.dummy_ptxas_log


### PR DESCRIPTION
This resolves #30 "[RFC] Handle sm_* which is no longer supported by CUDA / ptxas exec check or configure check?".

@vries, what do you think about this one?  With that installed, we may then revert GCC commit bf4832d6fa817f66009f100a9cd68953062add7d "[nvptx] Fix ASM_SPEC workaround for sm_30", and GCC commit 12fa7641ceed9c9139e2ea7b62c11f3dc5b6f6f4 "[nvptx] Use --no-verify for sm_30".
