### PR TITLE
Handle --hash-style argument in nvptx-ld

### DIFF
--- a/nvptx-ld.cc
+++ b/nvptx-ld.cc
@@ -390,7 +390,10 @@ Report bugs to %s.\n",
   exit (status);
 }
 
+#define OPT_hash_style 256
+
 static const struct option long_options[] = {
+  {"hash-style", required_argument, 0, OPT_hash_style },
   {"help", no_argument, 0, 'h' },
   {"version", no_argument, 0, 'V' },
   {0, 0, 0, 0 }
@@ -440,6 +443,9 @@ the GNU General Public License version 3 or later.\n\
 This program has absolutely no warranty.\n",
 		  PKGVERSION, NVPTX_TOOLS_VERSION, "2015");
 	  exit (0);
+	case OPT_hash_style:
+	  // Ignore --hash-style
+	  break;
 	default:
 	  usage (stderr, 1);
 	  break;


### PR DESCRIPTION
The gcc build infrastructure passes --hash-style=STYLE to the linker, including when building the offload compiler.  This fails with nvptx-ld because it does not understand the option.

The functionality selectd by this option it is not needed but to ease the use of the tools nvptx-ld could just ignore the option.

This patch does just that.  It could potentially be made more strict by checking for the exact option argument but there is not really a reason for that.  Regardless of how the host tools are build, the nvptx backend won't use the ELF hashing indicated.