### PR TITLE
ld: Accept --verbose as alias for -v

### DIFF
--- a/nvptx-ld.cc
+++ b/nvptx-ld.cc
@@ -726,7 +726,7 @@ usage (std::ostream &out_stream, int status)
 Usage: nvptx-none-ld [option...] [files]\n\
 Options:\n\
   -o FILE               Write output to FILE\n\
-  -v                    Be verbose\n\
+  --verbose, -v         Be verbose\n\
   -l LIBRARY            Link with LIBRARY\n\
   -L DIR                Search for libraries in DIR\n\
   --help                Print this help and exit\n\
@@ -746,6 +746,7 @@ static const struct option long_options[] = {
   {"hash-style", required_argument, 0, OPT_hash_style },
   {"help", no_argument, 0, 'h' },
   {"ignore-unresolved-symbol", required_argument, 0, OPT_ignore_unresolved_symbol },
+  {"verbose", no_argument, 0, 'v' },
   {"version", no_argument, 0, 'V' },
   {0, 0, 0, 0 }
 };


### PR DESCRIPTION
Before this commit, nvptx-ld only supported '-v' for verbose, while other compilers use it to print the version (and exit).  For better compatibility, this commit now adds '--verbose'.

This incompatibility is in particular an issue for offload compilation, where using '-foffload-options=nvptx-none=-Wl,--verbose' with GCC will pass those linker flags to both the offload-target compiler (nvptx-ld) and to the offload-host compiler, such that the flags should be better compatible.

Looking at other linkers:
* ld.bfd (GNU linker, part of Binutils) has --verbose[=n] while -v prints the version.
* ld.mold (Mold linker) uses --trace, but accepts (and ignores) --verbose while -v prints the version.
* ld.lld (LLVM linker) uses --verbose and -verbose while -v prints the version.
* ld.gold (Binutils' gold linker) supports --verbose as alias for --debug=files and -v is used to print the version.

@tschwinge 